### PR TITLE
Match the User Links UI to other menu items.

### DIFF
--- a/includes/classes/admin/menu-settings.php
+++ b/includes/classes/admin/menu-settings.php
@@ -48,6 +48,11 @@ class Menu_Settings {
 
 		<?php
 
+		$which_users_options = array(
+			''           => __( 'Everyone', 'user-menus' ),
+			'logged_out' => __( 'Logged Out Users', 'user-menus' ),
+			'logged_in'  => __( 'Logged In Users', 'user-menus' ),
+		);
 
 		if ( in_array( $item->object, array( 'login', 'register', 'logout' ) ) ) :
 
@@ -87,13 +92,29 @@ class Menu_Settings {
 
 			</p>
 
-		<?php else:
+			<p class="nav_item_options-which_users  description  description-wide">
 
-			$which_users_options = array(
-				''           => __( 'Everyone', 'user-menus' ),
-				'logged_out' => __( 'Logged Out Users', 'user-menus' ),
-				'logged_in'  => __( 'Logged In Users', 'user-menus' ),
-			); ?>
+				<label for="jp_nav_item_options-which_users-<?php echo $item->ID; ?>">
+
+					<?php _e( 'Who can see this link?', 'user-menus' ); ?>
+
+				</label>
+
+				<select n id="jp_nav_item_options-which_users-<?php echo $item->ID; ?>" class="widefat" disabled="disabled">
+					<option>
+						<?php
+						if('logout' == $item->object) {
+							echo $which_users_options['logged_in'];
+						} else {
+							echo $which_users_options['logged_out'];
+						}
+						?>
+					</option>
+				</select>
+
+			</p>
+
+		<?php else: ?>
 
 			<p class="nav_item_options-which_users  description  description-wide">
 


### PR DESCRIPTION
Adds the "Who can see this link?" setting to the User Link menu items (ie Login, Register, Logout), in a disabled state, to communicate that the visibility rule is inherently applied but does not need to be configured.

Closes #23.

![image](https://user-images.githubusercontent.com/10858303/68175012-d275a200-ff4d-11e9-84d1-0831d1c569e6.png)
